### PR TITLE
Accept royalroadl URLs including "www."

### DIFF
--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -31,7 +31,7 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
 
   val fictionLink = trailArg[String](required = true,
     descr = "Fiction URL in format: http://royalroadl.com/fiction/xxxx",
-    validate = _.matches("https?://royalroadl.com/fiction/\\d+"))
+    validate = _.matches("https?://(www\\.)?royalroadl.com/fiction/\\d+"))
 
   verify()
 }


### PR DESCRIPTION
Currently, royalroadl URLs include "www." by default, which is not acceped by the royalroadl-downloader. I extended the regular expression for validating the URLs to also accept URLs including "www.".