### PR TITLE
Provide explicit UTF-8 encoding for output

### DIFF
--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -81,9 +81,9 @@ object Main extends App {
   val filename = title.replaceAll("[^\\w\\d]+", "_") + ".html"
   println("Saving as: " + filename)
 
-  new PrintWriter(filename) {
+  new PrintWriter(filename, "UTF-8") {
     write(
-      s"""<html><head><title>$title</title></head><body>
+      s"""<html><head><meta charset="UTF-8"><title>$title</title></head><body>
          |${chaps.mkString("\n")}
          |</body>
          |</html>


### PR DESCRIPTION
Previously the downloader would dump everything in the default charset which caused some odd rendering.
This fixes the output encoding as well as setting the html meta charset