### PR TITLE
Improve URL Regex

### DIFF
--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -1,5 +1,6 @@
 package com.aivean.royalroad
 
+import com.aivean.royalroad.Args.urlValidationRegex
 import org.rogach.scallop._;
 
 class Args(args: Seq[String]) extends ScallopConf(args) {
@@ -33,7 +34,11 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
   val fictionLink = trailArg[String](required = true,
     descr = "Fiction URL in format: http://royalroad.com/fiction/xxxx\n" +
       "\tor http[s]://[www.]royalroad.com/fiction/xxxx/fiction-title",
-    validate = _.matches("https?://(www\\.)?royalroadl?.com/fiction/\\d+(/([^/]+))?/?"))
+    validate = _.matches(urlValidationRegex))
 
   verify()
+}
+
+object Args {
+  val urlValidationRegex = "https?://(www\\.)?royalroadl?.com/fiction/\\d+(/([^/]+))?/?"
 }

--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -33,7 +33,7 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
   val fictionLink = trailArg[String](required = true,
     descr = "Fiction URL in format: http://royalroad.com/fiction/xxxx\n" +
       "\tor http[s]://[www.]royalroad.com/fiction/xxxx/fiction-title",
-    validate = _.matches("https?://(www\\.)?royalroadl?.com/fiction/\\d+(/([^/]+)/?)?"))
+    validate = _.matches("https?://(www\\.)?royalroadl?.com/fiction/\\d+(/([^/]+))?/?"))
 
   verify()
 }

--- a/src/test/scala/com/aivean/royalroad/ArgsTest.scala
+++ b/src/test/scala/com/aivean/royalroad/ArgsTest.scala
@@ -1,0 +1,32 @@
+package com.aivean.royalroad
+
+import org.scalatest.FunSuite
+
+/**
+ *
+ * @author <a href="mailto:aiveeen@gmail.com">Ivan Zaitsev</a>
+ *         2021-04-19
+ */
+class ArgsTest extends FunSuite {
+
+  test("Url argument validation") {
+
+    for (
+      http <- List("http", "https");
+      www <- List("", "www.");
+      l <- List("", "l")
+    ) {
+      assert(s"${http}://${www}royalroad${l}.com/fiction/12345".matches(Args.urlValidationRegex))
+      assert(s"${http}://${www}royalroad${l}.com/fiction/12345/".matches(Args.urlValidationRegex))
+      assert(s"${http}://${www}royalroad${l}.com/fiction/12345/name".matches(Args.urlValidationRegex))
+      assert(s"${http}://${www}royalroad${l}.com/fiction/12345/na-me".matches(Args.urlValidationRegex))
+      assert(s"${http}://${www}royalroad${l}.com/fiction/12345/name/".matches(Args.urlValidationRegex))
+
+      assert(!s"${http}://${www}royalroad${l}.com/fiction/12345//".matches(Args.urlValidationRegex))
+      assert(!s"${http}://${www}royalroad${l}.com/fiction/".matches(Args.urlValidationRegex))
+      assert(!s"${http}://${www}royalroad${l}.com/fiction//".matches(Args.urlValidationRegex))
+      assert(!s"${http}://${www}royalroad${l}.com/fiction/123//".matches(Args.urlValidationRegex))
+      assert(!s"${http}://${www}royalroad${l}.com/fiction/123/name//".matches(Args.urlValidationRegex))
+    }
+  }
+}


### PR DESCRIPTION
Hi,

just noticed that there is a slight inconvenience caused by the URL parameter.
It allows:
`https://www.royalroad.com/fiction/xxxxx`
`https://www.royalroad.com/fiction/xxxxx/title`
`https://www.royalroad.com/fiction/xxxxx/title/`

But does not allow:
`https://www.royalroad.com/fiction/xxxxx/` (trailing slash without title)

This PR aims to also allow this specific case. 
Unfortunately I can't run scala for some reason. And thus can't test if this actually works, BUT: 
The Parsing should not be impeded, as the newly allowed variant resolves to the same webpage.

Greetings