### PR TITLE
Add option to strip Royal Road site title suffix from filename

### DIFF
--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -40,6 +40,11 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
     default = Some("div.chapter-content")
   )
 
+  val stripSiteTitle = opt[Boolean](
+    descr = "Remove the Royal Road site title part of the story in filename",
+    default = Some(false)
+  )
+
   val fictionLink = trailArg[String](required = true,
     descr = "Fiction URL in format: http://royalroad.com/fiction/xxxx\n" +
       "\tor http[s]://[www.]royalroad.com/fiction/xxxx/fiction-title",

--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -40,11 +40,6 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
     default = Some("div.chapter-content")
   )
 
-  val keepSiteTitle = opt[Boolean](
-    descr = "Keep the Royal Road site title part of the story in filename",
-    default = Some(false)
-  )
-
   val fictionLink = trailArg[String](required = true,
     descr = "Fiction URL in format: http://royalroad.com/fiction/xxxx\n" +
       "\tor http[s]://[www.]royalroad.com/fiction/xxxx/fiction-title",

--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -40,8 +40,8 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
     default = Some("div.chapter-content")
   )
 
-  val stripSiteTitle = opt[Boolean](
-    descr = "Remove the Royal Road site title part of the story in filename",
+  val keepSiteTitle = opt[Boolean](
+    descr = "Keep the Royal Road site title part of the story in filename",
     default = Some(false)
   )
 

--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -74,12 +74,9 @@ object Main extends App {
     chapQ.put(None)
   }
 
-  val filesafeRRSiteTitleSuffix = "_Royal_Road"
-  val filesafeTitle = title.replaceAll("[^\\w\\d]+", "_").stripSuffix(filesafeRRSiteTitleSuffix)
+  val filesafeTitle = title.stripSuffix(" | Royal Road").replaceAll("[^\\w\\d]+", "_")
 
   val filename = filesafeTitle + {
-    if (cliArgs.keepSiteTitle()) filesafeRRSiteTitleSuffix else ""
-  } + {
     // when chapter range is specified, add it to the filename
     if (chapUrls.size != chapUrlsConstrained.size) {
       val firstChapter = chapUrls.indexOf(chapUrlsConstrained.head)

--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -78,7 +78,7 @@ object Main extends App {
   val filesafeTitle = title.replaceAll("[^\\w\\d]+", "_").stripSuffix(filesafeRRSiteTitleSuffix)
 
   val filename = filesafeTitle + {
-    if (cliArgs.stripSiteTitle()) "" else filesafeRRSiteTitleSuffix
+    if (cliArgs.keepSiteTitle()) filesafeRRSiteTitleSuffix else ""
   } + {
     // when chapter range is specified, add it to the filename
     if (chapUrls.size != chapUrlsConstrained.size) {

--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -74,7 +74,12 @@ object Main extends App {
     chapQ.put(None)
   }
 
-  val filename = title.replaceAll("[^\\w\\d]+", "_") + {
+  val filesafeRRSiteTitleSuffix = "_Royal_Road"
+  val filesafeTitle = title.replaceAll("[^\\w\\d]+", "_").stripSuffix(filesafeRRSiteTitleSuffix)
+
+  val filename = filesafeTitle + {
+    if (cliArgs.stripSiteTitle()) "" else filesafeRRSiteTitleSuffix
+  } + {
     // when chapter range is specified, add it to the filename
     if (chapUrls.size != chapUrlsConstrained.size) {
       val firstChapter = chapUrls.indexOf(chapUrlsConstrained.head)


### PR DESCRIPTION
The site title is "Story Name | Royal Road" which gets transformed into "Story_Name_Royal_Road" for the filename.
Personally I don't care for the "_Royal_Road" part of the filename as I keep all my archived/saved stories from there in an appropriately named folder.

This commit adds the `--strip-site-title`/`-s` option to skip that part of the filename and just use the story name (and the chapter counts of course).