### PR TITLE
Add option to include download date in filename (off by default)

### DIFF
--- a/src/main/scala/com/aivean/royalroad/Args.scala
+++ b/src/main/scala/com/aivean/royalroad/Args.scala
@@ -40,6 +40,11 @@ class Args(args: Seq[String]) extends ScallopConf(args) {
     default = Some("div.chapter-content")
   )
 
+  val addIsoDate = opt[Boolean](
+    descr = "Add todays date in ISO format (YYYY-MM-DD) to the end of the filename",
+    default = Some(false)
+  )
+
   val fictionLink = trailArg[String](required = true,
     descr = "Fiction URL in format: http://royalroad.com/fiction/xxxx\n" +
       "\tor http[s]://[www.]royalroad.com/fiction/xxxx/fiction-title",

--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -9,6 +9,8 @@ import org.jsoup.Connection
 
 import java.io.PrintWriter
 import java.net.{URL, URLDecoder}
+import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.concurrent.ArrayBlockingQueue
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future, duration}
@@ -82,6 +84,12 @@ object Main extends App {
       if (firstChapter == lastChapter) "_chapter_" + (firstChapter + 1) else
         "_chapters_" + (firstChapter + 1) + "-" + (lastChapter + 1)
     } else ""
+  } + {
+    val isoDateFormat = new SimpleDateFormat("yyyy-MM-dd")
+    val filesafeIsoDate = isoDateFormat.format(Calendar.getInstance().getTime())
+    if (cliArgs.addIsoDate())
+      "_" + filesafeIsoDate
+    else ""
   } + ".html"
   println("Saving as: " + filename)
 


### PR DESCRIPTION
Introduce a new option to include the download date in ISO format (YYYY-MM-DD, e.g. 2024-01-18 for the 18th of January 2024) at the end of the filename.

I usually keep multiple versions of stories around to keep track of (stealth) edits of earlier chapters and also to prevent stubbing of works removing anything from my archive.

This commit adds the `--add-iso-date`/`-a` option which, as the name implies adds the current date to the filename as the last part before the extension.