### PR TITLE
Check divs as well as paragraphs for Royal Road warnings

### DIFF
--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -191,6 +191,17 @@ object Main extends App {
               println("removing warning: " + p.text)
               p.underlying.remove()
           }
+
+          // find all divs, since royal road put warnings in divs now as well
+          val warningDivs = chapterContent.select("div")
+          // find all warningDivs that contain the warning
+          val warningDivsParagraphs = warningDivs.filter(p => Utils.WarningFuzzyMatcher(p.text))
+          // remove all warning warningDivs
+          warningDivsParagraphs.collect {
+            case p: JsoupElement =>
+              println("removing warning: " + p.text)
+              p.underlying.remove()
+          }
         }
 
         // write chapter content to file

--- a/src/main/scala/com/aivean/royalroad/Main.scala
+++ b/src/main/scala/com/aivean/royalroad/Main.scala
@@ -181,23 +181,12 @@ object Main extends App {
         }
 
         if (cliArgs.removeWarnings()) {
-          // find all paragraphs
-          val paragraphs = chapterContent.select("p")
+          // find all paragraphs and divs, since Royal Road seems to put warnings in divs now.
+          val paragraphs = chapterContent.select("p,div")
           // find all paragraphs that contain the warning
           val warningParagraphs = paragraphs.filter(p => Utils.WarningFuzzyMatcher(p.text))
           // remove all warning paragraphs
           warningParagraphs.collect {
-            case p: JsoupElement =>
-              println("removing warning: " + p.text)
-              p.underlying.remove()
-          }
-
-          // find all divs, since royal road put warnings in divs now as well
-          val warningDivs = chapterContent.select("div")
-          // find all warningDivs that contain the warning
-          val warningDivsParagraphs = warningDivs.filter(p => Utils.WarningFuzzyMatcher(p.text))
-          // remove all warning warningDivs
-          warningDivsParagraphs.collect {
             case p: JsoupElement =>
               println("removing warning: " + p.text)
               p.underlying.remove()


### PR DESCRIPTION
Royal road seems to be putting its anti-piracy warnings into divs as well as paragraphs now. (Or just instead of paragraphs?)

This changelist just duplicates the code that checks for warnings in html paragraphs and also checks for them in html divs.